### PR TITLE
Feature/claiming bounty should open discord link in the new tab

### DIFF
--- a/packages/react-app/src/components/pages/Bounties/Bounty/index.tsx
+++ b/packages/react-app/src/components/pages/Bounties/Bounty/index.tsx
@@ -122,6 +122,7 @@ const BountyDetails = ({
 				<>
 					<Heading size="sm">Claimed By</Heading>
 					<AccessibleLink
+						isExternal={true}
 						href={
 							discordMessageId
 								? `${discordChannelUrl}/${discordMessageId}`

--- a/packages/react-app/src/components/pages/Bounties/Bounty/index.tsx
+++ b/packages/react-app/src/components/pages/Bounties/Bounty/index.tsx
@@ -122,7 +122,6 @@ const BountyDetails = ({
 				<>
 					<Heading size="sm">Claimed By</Heading>
 					<AccessibleLink
-						isExternal={true}
 						href={
 							discordMessageId
 								? `${discordChannelUrl}/${discordMessageId}`


### PR DESCRIPTION
Fixes #166 