### PR TITLE
Fix/loading 404

### DIFF
--- a/packages/react-app/.eslintrc.json
+++ b/packages/react-app/.eslintrc.json
@@ -29,6 +29,7 @@
     "@typescript-eslint/indent": 0,
     "@typescript-eslint/member-delimiter-style": 0,
     "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/ban-ts-comment": 0,
     "@typescript-eslint/no-var-requires": 0,
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-unused-vars": [

--- a/packages/react-app/src/components/pages/Bounties/Bounty/index.tsx
+++ b/packages/react-app/src/components/pages/Bounties/Bounty/index.tsx
@@ -11,15 +11,11 @@ import {
 	Heading,
 	Tag,
 	TagLabel,
-	Stack,
 	Text,
 } from '@chakra-ui/react';
 import AccessibleLink from '../../../parts/AccessibleLink';
-
 import { BountyCollection } from '../../../../models/Bounty';
 import { baseUrl } from '../../../../constants/discordInfo';
-import Link from 'next/link';
-import ColorModeButton from '../../../../components/parts/ColorModeButton';
 import { CustomerContext } from '../../../../context/CustomerContext';
 import { useContext } from 'react';
 
@@ -145,26 +141,7 @@ const BountyDetails = ({
 	);
 };
 
-const BountyNotFound = (): JSX.Element => (
-	<Stack align="center" justify="center" h="400px">
-		<Heading size="4xl" align="center">
-			<strong>404</strong>
-		</Heading>
-		<Box>
-			<Heading size="xl">Bounty not found</Heading>
-		</Box>
-		<Link href='/'>
-			<Box my="5">
-				<ColorModeButton>Go Back</ColorModeButton>
-			</Box>
-		</Link>
-	</Stack>
-);
-
 export const BountyCard = (props: BountyCollection): JSX.Element => {
-	if (!props || Object.entries(props).length === 0) {
-		return (<BountyNotFound />);
-	}
 	return (
 		<Box width={{ base: '95vw', lg: '700px' }}>
 			<Box borderWidth={3} borderRadius={10} mb={3} p={4}>

--- a/packages/react-app/src/components/pages/Bounties/Filters/bountyPaginate.tsx
+++ b/packages/react-app/src/components/pages/Bounties/Filters/bountyPaginate.tsx
@@ -1,0 +1,49 @@
+import { useColorMode } from '@chakra-ui/color-mode';
+import { Stack, Button } from '@chakra-ui/react';
+
+type BountyPaginateProps = {
+  page: number;
+  setPage(page: number): void;
+  maxPages: number;
+}
+
+function BountyPaginate({ page, setPage, maxPages }: BountyPaginateProps) {
+
+	const { colorMode } = useColorMode();
+
+	const incrementPage = (): void => {
+		// pages are 0 indexed
+		setPage(Math.min(page + 1, maxPages - 1));
+		window.scrollTo(0, 0);
+	};
+
+	const decrementPage = (): void => {
+		setPage(Math.max(page - 1, 0));
+		window.scrollTo(0, 0);
+	};
+
+	return (
+		<Stack justify="space-between" direction="row" mt={3}>
+			<Button
+				p={5}
+				disabled={page === 0}
+				size="sm"
+				bg={colorMode === 'light' ? 'primary.300' : 'primary.700'}
+				onClick={decrementPage}
+			>
+      &larr; Previous Page
+			</Button>
+			<Button
+				p={5}
+				disabled={page === maxPages - 1 || maxPages === 0}
+				size="sm"
+				bg={colorMode === 'light' ? 'primary.300' : 'primary.700'}
+				onClick={incrementPage}
+			>
+      Next Page &rarr;
+			</Button>
+		</Stack>
+	);
+}
+
+export default BountyPaginate;

--- a/packages/react-app/src/components/pages/Bounties/index.tsx
+++ b/packages/react-app/src/components/pages/Bounties/index.tsx
@@ -1,25 +1,38 @@
-import { Button, Stack, Text, useColorMode } from '@chakra-ui/react';
+import { Stack, Text } from '@chakra-ui/react';
 import BountyAccordion from './BountyAccordion';
-import useSWR from 'swr';
-import { BountyCard } from './Bounty';
 import React, { useContext, useEffect, useState } from 'react';
 import Filters from './Filters';
 import useDebounce from '../../../hooks/useDebounce';
 import { CustomerContext } from '../../../context/CustomerContext';
 import { BANKLESS } from '../../../constants/Bankless';
-
-export type PreFilterProps = {
-  id?: string | string[]
-}
+import useBounties from '../../../hooks/useBounties';
+import { BountyCollection } from '../../../models/Bounty';
+import BountyPaginate from './Filters/bountyPaginate';
 
 export const PAGE_SIZE = 10;
 
-const fetcher = (url: string) =>
-	fetch(url)
-		.then((res) => res.json())
-		.then((json) => json.data);
+const maxPages = (bounties: BountyCollection | BountyCollection[] | undefined) => {
+	if (!bounties || !Array.isArray(bounties)) return 0;
+	const numFullPages = Math.floor(bounties.length / PAGE_SIZE);
+	const hasExtraPage = bounties.length % PAGE_SIZE != 0;
+	return hasExtraPage ? numFullPages + 1 : numFullPages;
+};
 
-const Bounties = ({ id }: PreFilterProps): JSX.Element => {
+const NoResults = () => (
+	<Stack
+		borderWidth={3}
+		borderRadius={10}
+		width={{ base: '95vw', lg: '700px' }}
+		textalign="center"
+		direction="row"
+		justify="center"
+		align="center"
+	>
+		<Text	fontSize="lg">Found <strong>0</strong> matching results</Text>
+	</Stack>
+);
+
+const Bounties = (): JSX.Element => {
 	/* Bounties will fetch all data to start, unless a single bounty is requested */
 	const [page, setPage] = useState(0);
 	const [status, setStatus] = useState('Open');
@@ -30,29 +43,9 @@ const Bounties = ({ id }: PreFilterProps): JSX.Element => {
 	const [sortBy, setSortBy] = useState('');
 	const [sortAscending, setSortAscending] = useState(true);
 	const debounceSearch = useDebounce(search, 500, true);
-	const { colorMode } = useColorMode();
 
 	const { customer } = useContext(CustomerContext);
 	const { customer_id } = customer;
-
-	const maxPages = () => {
-		if (!bounties) return 0;
-		const numFullPages = Math.floor(bounties.length / PAGE_SIZE);
-		const hasExtraPage = bounties.length % PAGE_SIZE != 0;
-		return hasExtraPage ? numFullPages + 1 : numFullPages;
-	};
-
-	const incrementPage = () => {
-		// pages are 0 indexed
-		setPage(Math.min(page + 1, maxPages() - 1));
-
-		window.scrollTo(0, 0);
-	};
-
-	const decrementPage = () => {
-		setPage(Math.max(page - 1, 0));
-		window.scrollTo(0, 0);
-	};
 
 	let dynamicUrl = '/api/bounties';
 	dynamicUrl += `?status=${status === '' ? 'All' : status}`;
@@ -62,22 +55,19 @@ const Bounties = ({ id }: PreFilterProps): JSX.Element => {
 	dynamicUrl += `&sortBy=${sortBy}`;
 	dynamicUrl += `&asc=${sortAscending}`;
 	dynamicUrl += `&customer_id=${customer_id ?? BANKLESS.customer_id}`;
-		
-	const { data: bounties, error } = useSWR(
-		id ? `/api/bounties/${id}` : dynamicUrl,
-		fetcher
-	);
 
 	useEffect(() => {
 		setPage(0);
 	}, [search, gte, lte, sortBy]);
 
-	if (error) return <p>Failed to load</p>;
+	const { bounties, isLoading, isError } = useBounties(dynamicUrl);
 
-	const paginatedBounties =
-    !id && bounties &&
-    bounties.slice(PAGE_SIZE * page, Math.min(bounties.length, PAGE_SIZE * (page + 1)));
+	const paginatedBounties = bounties
+		? bounties.slice(PAGE_SIZE * page, Math.min(bounties.length, PAGE_SIZE * (page + 1)))
+		: [];
 
+	if (isError) return <p>Failed to load</p>;
+	if (isLoading) return <p>Loading</p>;
 	return (
 		<>
 			<Stack
@@ -87,49 +77,24 @@ const Bounties = ({ id }: PreFilterProps): JSX.Element => {
 				fontWeight="600"
 				gridGap="4"
 			>
-				{ id
-					? (<BountyCard {...bounties} />)
-					: (
-						<>
-							<Filters
-								status={status} setStatus={setStatus}
-								search={search} setSearch={setSearch}
-								lte={lte} setLte={setLte}
-								gte={gte} setGte={setGte}
-								sortBy={sortBy} setSortBy={setSortBy}
-								sortAscending={sortAscending} setSortAscending={setSortAscending}
-							/>
-							{(search || status) && bounties && paginatedBounties.length === 0 ?
-								<Stack borderWidth={3} borderRadius={10} width={{ base: '95vw', lg: '700px' }} textalign="center" direction="row" justify="center" align="center">
-									<Text fontSize="lg">Found </Text><Text fontSize="lg" fontFamily="mono" fontWeight="bold">0</Text><Text fontSize="lg"> matching results</Text>
-								</Stack> :
-								<BountyAccordion bounties={paginatedBounties} />
-							}
-						</>
-					)}
+				<Filters
+					status={status} setStatus={setStatus}
+					search={search} setSearch={setSearch}
+					lte={lte} setLte={setLte}
+					gte={gte} setGte={setGte}
+					sortBy={sortBy} setSortBy={setSortBy}
+					sortAscending={sortAscending} setSortAscending={setSortAscending}
+				/>
+				{(search || status) && bounties && paginatedBounties.length === 0
+					? <NoResults />
+					: <BountyAccordion bounties={paginatedBounties} />
+				}
 			</Stack>
-			{!id && (
-				<Stack justify="space-between" direction="row" mt={3}>
-					<Button
-						p={5}
-						disabled={page === 0}
-						size="sm"
-						bg={colorMode === 'light' ? 'primary.300' : 'primary.700'}
-						onClick={decrementPage}
-					>
-            &larr; Previous Page
-					</Button>
-					<Button
-						p={5}
-						disabled={page === maxPages() - 1 || bounties && paginatedBounties.length === 0}
-						size="sm"
-						bg={colorMode === 'light' ? 'primary.300' : 'primary.700'}
-						onClick={incrementPage}
-					>
-            Next Page &rarr;
-					</Button>
-				</Stack>
-			)}
+			<BountyPaginate
+				page={page}
+				setPage={setPage}
+				maxPages={maxPages(bounties)}
+			/>
 		</>
 	);
 };

--- a/packages/react-app/src/hooks/useBounties.ts
+++ b/packages/react-app/src/hooks/useBounties.ts
@@ -1,0 +1,53 @@
+import { BountyCollection } from '../models/Bounty';
+import useSWR from 'swr';
+import axios from '../utils/AxiosUtils';
+
+// axios returns an AxiosResponse, with the payload in the `data` object
+const axiosFetcher = (url: string) => axios.get(url).then(({ data }) => data.data);
+
+interface BountySWRResponse {
+  isLoading: boolean;
+  isError: boolean;
+}
+
+interface useBountiesResponse extends BountySWRResponse {
+  bounties?: BountyCollection[]
+}
+
+interface useBountyResponse extends BountySWRResponse {
+  bounty?: BountyCollection
+}
+
+export function useBounties(url: string): useBountiesResponse {
+	/**
+   * Wraps the SWR hook with additional loading state for spinners
+   */
+	const { data, error } = useSWR<BountyCollection[], unknown>(url, axiosFetcher);
+	return {
+		bounties: data,
+		isLoading: !error && !data,
+		isError: !!error,
+	};
+}
+
+export function useBounty(id?: string | string[]): useBountyResponse {
+	/**
+   * Single bounty
+   */
+
+	const { data, error } = useSWR<BountyCollection, unknown>(`/api/bounties/${id}`, axiosFetcher);
+	if (typeof id !== 'string') {
+		return {
+			bounty: undefined,
+			isLoading: false,
+			isError: true,
+		};
+	}
+	return {
+		bounty: data,
+		isLoading: !error && !data,
+		isError: !!error,
+	};
+}
+
+export default useBounties;

--- a/packages/react-app/src/models/Bounty.ts
+++ b/packages/react-app/src/models/Bounty.ts
@@ -7,6 +7,10 @@ import {
 	array,
 	mixed,
 } from 'yup';
+
+// Have to use ignore here due to some strange error with typescript not picking
+// up the declaration file, unless you change the name every deploy
+// @ts-ignore
 import mongoosePaginate from 'mongo-cursor-pagination';
 
 type RequiredForPostProps = { method: 'POST' | 'PATCH', schema: any, isObject?: boolean };

--- a/packages/react-app/src/pages/[id]/index.tsx
+++ b/packages/react-app/src/pages/[id]/index.tsx
@@ -1,21 +1,66 @@
-import { Flex } from '@chakra-ui/layout';
-import { CustomerContext } from '../../context/CustomerContext';
-import { useRouter } from 'next/router';
 import { useContext } from 'react';
+import { useRouter } from 'next/router';
+import { Stack, Heading, Link, Box } from '@chakra-ui/layout';
+import { SkeletonCircle, SkeletonText } from '@chakra-ui/skeleton';
+import { CustomerContext } from '../../context/CustomerContext';
 import Layout from '../../components/global/SiteLayout';
-import Bounties from '../../components/pages/Bounties';
+import { BountyCard } from '../../components/pages/Bounties/Bounty';
+import { useBounty } from '../../hooks/useBounties';
+import ColorModeButton from '../../components/parts/ColorModeButton';
 
-const BountyPage = (): JSX.Element => {
+export const BountyNotFound = (): JSX.Element => (
+	<Stack align="center" justify="center" h="400px">
+		<Heading size="4xl" align="center">
+			<strong>404</strong>
+		</Heading>
+		<Box>
+			<Heading size="xl">Bounty not found</Heading>
+		</Box>
+		<Link href='/'>
+			<Box my="5">
+				<ColorModeButton>Go Back</ColorModeButton>
+			</Box>
+		</Link>
+	</Stack>
+);
+
+export const BountyLoader = () => (
+	<Box padding='6' boxShadow='lg'>
+		<SkeletonCircle size='10' />
+		<SkeletonText mt='4' noOfLines={10} spacing='4' />
+	</Box>
+);
+
+export const BountyPage = (): JSX.Element => {
 	const router = useRouter();
 	const { id } = router.query;
+	const { bounty, isLoading, isError } = useBounty(id);
+	return (
+		<>{
+			isLoading
+				? <BountyLoader />
+				: bounty ?
+					<Stack
+						direction={{ base: 'column', lg: 'row' }}
+						align="top"
+						fontSize="sm"
+						fontWeight="600"
+						gridGap="4"
+					>
+						<BountyCard {...bounty} />
+					</Stack>
+					: (id && isError) && <BountyNotFound />
+		}</>
+	);
+};
+
+const BountyPageLayout = (): JSX.Element => {
 	const { customer } = useContext(CustomerContext);
 	return (
 		<Layout title={`${customer.customerName ?? 'DAO'} Bounty Board`}>
-			<Flex align="center" justify="center">
-				<Bounties id={id} />
-			</Flex>
+			<BountyPage />
 		</Layout>
 	);
 };
 
-export default BountyPage;
+export default BountyPageLayout;

--- a/packages/react-app/src/utils/AxiosUtils.ts
+++ b/packages/react-app/src/utils/AxiosUtils.ts
@@ -9,3 +9,4 @@ export default axios.create({
 		'Content-Type': 'application/json',
 	},
 });
+

--- a/packages/react-app/tsconfig.json
+++ b/packages/react-app/tsconfig.json
@@ -25,7 +25,14 @@
       "@tests/*": ["tests/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js", "../../mongo/abc.test.tsx"],
+  "include": [
+    "next-env.d.ts",
+    "mongo-cursor-paginate.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "../../mongo/abc.test.tsx"
+  ],
   "exclude": [
     "node_modules",
     ".next", 


### PR DESCRIPTION
NOTE: this fix builds off the [PR for api-v2](https://github.com/BanklessDAO/bounty-board/pull/163), and is intended to be pushed to develop after that branch.


This fix removes the pop in showing a 404 page whilst a bounty is loading.

While investigating the fix, I noticed a significant number of re-renders on the main bounties page leading to several unneccessary calls. What we then did was:

- Split the bounty accordion from the single bounty page, instead of conditionally rendering based on whether an `id` param is passed
- Extract some of the data fetching logic into hooks
- Remove conditional logic in the bounties page, as it now will _only_ render an array
- Added unit tests for the frontend single  bounty page in jest/enzyme.