### PR TITLE
RBAC and caching enabled

### DIFF
--- a/packages/react-app/.eslintrc.json
+++ b/packages/react-app/.eslintrc.json
@@ -32,6 +32,7 @@
     "@typescript-eslint/ban-ts-comment": 0,
     "@typescript-eslint/no-var-requires": 0,
     "@typescript-eslint/no-use-before-define": 0,
+    "no-mixed-spaces-and-tabs": 0,
     "@typescript-eslint/no-unused-vars": [
       2,
       {

--- a/packages/react-app/src/hooks/useRoles.ts
+++ b/packages/react-app/src/hooks/useRoles.ts
@@ -1,6 +1,5 @@
 import { Role } from '@app/types/Role';
 import { axiosFetcher } from '@app/utils/AxiosUtils';
-import { useSession } from 'next-auth/react';
 import useSWR from 'swr';
 
 export const useRoles = (): Role[] => {
@@ -11,16 +10,13 @@ export const useRoles = (): Role[] => {
 	 * Note, we currently only support roles in bankless, and need to establish a more complete
 	 * Auth method for multitenancy
    */
-	const { data: session } = useSession({ required: false });
-	const { data: roles, error } = useSWR<Role[], unknown>(
-		session
-			? ['/api/auth/roles', session.accessToken]
-			: null,
+	const { data, error } = useSWR<{ roles: Role[] }, unknown>(
+		'/api/auth/roles',
 		axiosFetcher,
 	);
 	if (error) {
 		console.warn(error);
 		return [];
 	}
-	return roles ?? [];
+	return (data && data.roles) ?? [];
 };

--- a/packages/react-app/src/models/RoleCache.ts
+++ b/packages/react-app/src/models/RoleCache.ts
@@ -1,0 +1,19 @@
+import { Role } from '@app/types/Role';
+import Mongoose, { Model } from 'mongoose';
+
+export interface IRoleCache{
+  sessionHash: string;
+  createdAt: number;
+  tte: number;
+  roles: Role[]
+}
+
+export const RoleSchema = new Mongoose.Schema({
+	sessionHash: String,
+	createdAt: Number,
+	tte: Number,
+	roles: Array,
+});
+
+export default Mongoose.models.RoleCache as Model<IRoleCache>
+|| Mongoose.model<IRoleCache>('RoleCache', RoleSchema);

--- a/packages/react-app/src/pages/api/auth/roles.ts
+++ b/packages/react-app/src/pages/api/auth/roles.ts
@@ -1,4 +1,5 @@
 import * as service from '@app/services/auth.service';
+import { SessionWithToken } from '@app/types/SessionExtended';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getSession } from 'next-auth/react';
 
@@ -12,10 +13,18 @@ const handler = async (
 		try {
 			const session = await getSession({ req });
 			if (session && session.accessToken) {
-				const roles = await service.getPermissions(session.accessToken as string);
-				res.status(200).json({ success: true, data: roles });
+				const roles = await service.getPermissionsCached(session as SessionWithToken);
+				res.status(200).json({
+					success: true,
+					data: {
+						roles,
+					},
+				});
 			} else {
-				res.status(401).json({ success: false, error: 'No session found' });
+				res.status(200).json({ success: 200, data: {
+					roles: [],
+					notes: 'No session found',
+				} });
 			}
 		} catch (error: any) {
 			res.status(error.status ?? 400).json({ success: false, error: error?.response?.statusText });

--- a/packages/react-app/src/services/auth.service.ts
+++ b/packages/react-app/src/services/auth.service.ts
@@ -1,14 +1,19 @@
 import { BANKLESS_ROLES } from '@app/constants/Roles';
 import { Role } from '@app/types/Role';
 import * as discordService from './discord.service';
+import { SessionWithToken } from '@app/types/SessionExtended';
+import * as crypto from 'crypto';
+import RoleCache, { IRoleCache } from '@app/models/RoleCache';
+import { Document } from 'mongoose';
+
+export const FIVE_MINUTES = 5 * 60 * 1_000;
+const ROLE_IDS = Object.values(BANKLESS_ROLES);
 
 /**
  * The auth service is aiming to wrap several other identity provdiers and
  * return a list of roles associated with the current user.
  * This can then be called by middlwares or directly in API endpoints
  */
-
-const ROLE_IDS = Object.values(BANKLESS_ROLES);
 
 export const getPermissions = async (accessToken: string): Promise<Role[]> => {
 	/**
@@ -18,7 +23,6 @@ export const getPermissions = async (accessToken: string): Promise<Role[]> => {
 	// note: only currently supports bankless
 	const banklessRolesForUser = await getRolesForUserInGuild(accessToken);
 	const permissions: Role[] = [];
-	console.debug({ banklessRolesForUser, ROLE_IDS });
 	if (banklessRolesForUser.includes(BANKLESS_ROLES.LEVEL_2)) permissions.push('create-bounty');
 	if (banklessRolesForUser.includes(BANKLESS_ROLES.BB_CORE)) permissions.push('admin');
 	return permissions;
@@ -33,6 +37,65 @@ export const getRolesForUserInGuild = async (
     */
 	// currently only supports bankless
 	const discordUserStats = await discordService.getDiscordUserInGuild(accessToken);
-	console.debug(discordUserStats.data.roles);
 	return discordUserStats.data.roles.filter(role => ROLE_IDS.includes(role));
+};
+
+export const createSessionHash = (session: SessionWithToken): string => {
+	// expires is regenerated every time but lasts for much longer than our cache
+	const { expires, ...invariants } = session; expires;
+	const sessionString = JSON.stringify(invariants);
+	return crypto
+		.createHash('sha256')
+		.update(sessionString)
+		.digest('base64');
+};
+
+export const cacheExpired = (cache: IRoleCache): boolean => {
+	return cache.createdAt + cache.tte <= new Date().getTime();
+};
+
+export const cacheValid = (cache: IRoleCache, sessionHash: string): boolean => {
+	const notExpired = !cacheExpired(cache);
+	const unchangedSessionHash = sessionHash === cache.sessionHash;
+	return notExpired && unchangedSessionHash;
+};
+
+export const generateCacheObject = (sessionHash: string, roles: Role[]): IRoleCache => ({
+	createdAt: new Date().getTime(),
+	roles,
+	sessionHash,
+	tte: FIVE_MINUTES,
+});
+
+export const createCache = async (
+	cache: Document<IRoleCache> | null,
+	sessionHash: string,
+	token: string
+): Promise<IRoleCache> => {
+	await cache?.remove();
+	const roles = await getPermissions(token);
+	const newCache = generateCacheObject(sessionHash, roles);
+	await RoleCache.create(newCache);
+	return newCache;
+};
+
+export const getPermissionsCached = async (session: SessionWithToken, flush = true): Promise<Role[]> => {
+	if (flush) flushCache();
+	const sessionHash = createSessionHash(session);
+	const cache = await RoleCache.findOne({ sessionHash });
+	if (cache && cacheValid(cache, sessionHash)) {
+		return cache.roles;
+	} else {
+		const newCache = await createCache(cache, sessionHash, session.accessToken);
+		return newCache.roles;
+	}
+};
+
+const flushCache = async (): Promise<void> => {
+	/**
+	 * Periodically call to remove records older than 5 minutes.
+	 * Keep as synchronous method in order not to impact performance
+	 */
+	const TenMinsAgo = new Date().getTime() - (2 * FIVE_MINUTES);
+	await RoleCache.deleteMany({ createdAt: { $lte: TenMinsAgo } });
 };

--- a/packages/react-app/src/types/SessionExtended.ts
+++ b/packages/react-app/src/types/SessionExtended.ts
@@ -5,4 +5,5 @@ import { Session } from 'next-auth';
  */
 export type SessionWithToken = Session & {
   accessToken: string;
+  expires: string;
 }

--- a/packages/react-app/tests/integration/api/auth.spec.ts
+++ b/packages/react-app/tests/integration/api/auth.spec.ts
@@ -1,0 +1,133 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createMocks, MockResponse, MockRequest } from 'node-mocks-http';
+import { Connection } from 'mongoose';
+import dbConnect from '@app/utils/dbConnect';
+import roleHandler from '@app/pages/api/auth/roles';
+import RoleCache, { IRoleCache } from '@app/models/RoleCache';
+import * as service from '@app/services/auth.service';
+import * as nextAuth from 'next-auth/react';
+import { SessionWithToken } from '@app/types/SessionExtended';
+
+describe('Testing the Role Caching', () => {
+	let connection: Connection;
+	let req: MockRequest<NextApiRequest>;
+	let res: MockResponse<NextApiResponse>;
+
+	const mockSession: SessionWithToken = {
+		accessToken: 'TESTTESTTEST',
+		expires: new Date().toDateString(),
+		user: {
+			email: 'test@test.com',
+			name: 'Jordan',
+		},
+	};
+
+	const altMockSession: SessionWithToken = {
+		...mockSession,
+		user: {
+			email: 'notTest@not.test.com',
+			name: 'notJordan',
+		},
+	};
+
+	let [spy]: jest.SpyInstance[] = [];
+
+	beforeAll(async () => {
+		const connect = await dbConnect();
+		connection = connect.connections[0];
+	});
+  
+	afterAll(async () => {
+		await connection.close();
+	});
+  
+	beforeEach(() => {
+		spy = jest.spyOn(service, 'getPermissions').mockResolvedValue(['admin']);
+		jest.spyOn(nextAuth, 'getSession').mockResolvedValue(mockSession);
+		const output = createMocks();
+		req = output.req;
+		req.method = 'GET';
+		res = output.res;
+	});
+
+	afterEach(async () => {
+		jest.clearAllMocks();
+		await RoleCache.deleteMany();
+	});
+
+	it('Grabs the role from discord if we do not have a cached role', async () => {
+		await roleHandler(req, res);
+		expect(res.statusCode).toEqual(200);
+		expect(res._getJSONData().data.roles).toEqual(['admin']);
+		expect(spy).toHaveBeenCalled();
+	});
+
+	it('Creates a cache record in the DB', async () => {
+		await roleHandler(req, res);
+		const roleCache = await RoleCache.find();
+		expect(roleCache.length).toEqual(1);
+	});
+
+	it('Uses the cached record second time around', async () => {
+		await roleHandler(req, res);
+		await roleHandler(req, res);
+		const roleCache = await RoleCache.find();
+		expect(roleCache.length).toEqual(1);
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it('Creates a different cache record if the user changes', async () => {
+		jest.spyOn(nextAuth, 'getSession').mockResolvedValueOnce(mockSession);
+		await roleHandler(req, res);
+
+		jest.spyOn(nextAuth, 'getSession').mockResolvedValueOnce(altMockSession);
+		await roleHandler(req, res);
+
+		const roleCache = await RoleCache.find();
+		expect(roleCache.length).toEqual(2);
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
+	it('Invalidates the cache if the cache expires', async () => {
+		// create a cache record
+		const cacheExpired: IRoleCache = {
+			createdAt: new Date().getTime() - service.FIVE_MINUTES - 1,
+			roles: ['admin'],
+			sessionHash: service.createSessionHash(mockSession),
+			tte: service.FIVE_MINUTES,
+		};
+		await RoleCache.create(cacheExpired);
+
+		spy = jest.spyOn(service, 'getPermissions').mockResolvedValue(['create-customer']);
+
+		await roleHandler(req, res);
+		const roleCache = await RoleCache.find();
+		expect(roleCache.length).toEqual(1);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(res._getJSONData().data.roles).toEqual(['create-customer']);
+	});
+
+	it('Flushes all cache records that are older than 10 minutes', async () => {
+		const cacheExpired: IRoleCache = {
+			createdAt: new Date().getTime() - service.FIVE_MINUTES - 1,
+			roles: ['admin'],
+			sessionHash: service.createSessionHash(mockSession),
+			tte: service.FIVE_MINUTES,
+		};
+		const cacheStale = {
+			...cacheExpired,
+			createdAt: new Date().getTime() - service.FIVE_MINUTES * 2,
+		};
+		const cacheOkay = {
+			...cacheExpired,
+			createdAt: new Date().getTime() - 100,
+		};
+
+		await RoleCache.create([cacheExpired, cacheOkay, cacheStale]);
+
+		await roleHandler(req, res);
+
+		const roleCache = await RoleCache.find();
+		expect(roleCache.length).toEqual(2);
+	});
+});

--- a/packages/react-app/tests/unit/services/auth.service.spec.ts
+++ b/packages/react-app/tests/unit/services/auth.service.spec.ts
@@ -1,0 +1,99 @@
+import { SessionWithToken } from '@app/types/SessionExtended';
+import * as service from '@app/services/auth.service';
+import RoleCache, { IRoleCache } from '@app/models/RoleCache';
+import { Document } from 'mongoose';
+
+describe('Role caching', () => {
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+  // used when mocking return values that don't exactly match
+  type CoercedIRoleCache = IRoleCache & Document<IRoleCache>
+
+  const noFlush = false;
+
+  const mockBaseSession: SessionWithToken = {
+  	accessToken: 'TestToken',
+  	expires: new Date().toDateString(),
+  	user: {
+  		email: 'abc@xyz/com',
+  		name: 'jordan',
+  	},
+  };
+  const mockCacheInvalid: IRoleCache = {
+  	tte: service.FIVE_MINUTES,
+  	createdAt: new Date().getTime() - 6 * 60 * 1_000,
+  	sessionHash: service.createSessionHash(mockBaseSession),
+  	roles: ['create-bounty', 'create-customer'],
+  };
+
+  const mockCacheValid: IRoleCache = {
+  	...mockCacheInvalid,
+  	createdAt: new Date().getTime(),
+  	roles: ['create-bounty'],
+  };
+
+  it('Creates a hash of the session that changes when session changges', () => {
+  	const modifiedSession = JSON.parse(JSON.stringify(mockBaseSession));
+  	modifiedSession.expires = 'Different Date';
+
+  	const baseHash = service.createSessionHash(mockBaseSession);
+  	const modifiedHash = service.createSessionHash(modifiedSession);
+  	expect(baseHash).not.toEqual(modifiedHash);
+  });
+
+  it('Creates a hash of the session that stays same when session unchanged', () => {
+  	const clonedSession = JSON.parse(JSON.stringify(mockBaseSession));
+  	const baseHash = service.createSessionHash(mockBaseSession);
+  	const clonedHash = service.createSessionHash(clonedSession);
+  	expect(baseHash).toEqual(clonedHash);
+  });
+
+  it('Expires the cache after 5 minutes', () => {
+  	const cachedSession = service.generateCacheObject(service.createSessionHash(mockBaseSession), ['admin']);
+  	expect(service.cacheExpired(cachedSession)).toEqual(false);
+  	cachedSession.createdAt = new Date().getTime() - (4 * 60 * 1000);
+  	expect(service.cacheExpired(cachedSession)).toEqual(false);
+  	cachedSession.createdAt = new Date().getTime() - (5 * 60 * 1000 + 1);
+  	expect(service.cacheExpired(cachedSession)).toEqual(true);
+  });
+
+  it('Returns the existing cache if valid and exists', async () => {
+  	const mockCache: IRoleCache = {
+  		tte: service.FIVE_MINUTES,
+  		createdAt: new Date().getTime() - 2 * 60 * 1_000,
+  		sessionHash: service.createSessionHash(mockBaseSession),
+  		roles: ['create-bounty', 'create-customer'],
+  	};
+  	// we don't care about mongoose methods for this test 
+  	jest.spyOn(RoleCache, 'findOne')
+  		.mockResolvedValue(mockCache as unknown as CoercedIRoleCache);
+
+  	expect(await service.getPermissionsCached(mockBaseSession, noFlush)).toEqual(mockCache.roles);
+  });
+
+  it('Calls the create method if the cache does not exist', async () => {
+  	jest.spyOn(RoleCache, 'findOne')
+  		.mockResolvedValue(null);
+
+  	const spy = jest.spyOn(service, 'createCache')
+  		.mockResolvedValue(mockCacheValid);
+
+  	await service.getPermissionsCached(mockBaseSession, noFlush);
+  	expect(spy).toHaveBeenCalled();
+  });
+
+  it('Calls the create method if the cache exists but is invalid', async () => {
+
+  	// we don't care about mongoose methods for this test 
+  	jest.spyOn(RoleCache, 'findOne')
+  		.mockResolvedValue(mockCacheInvalid as unknown as CoercedIRoleCache);
+  	const spy = jest.spyOn(service, 'createCache')
+  		.mockResolvedValue(mockCacheValid);
+
+  	await service.getPermissionsCached(mockBaseSession, noFlush);
+  	expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Simple RBAC configurable by route is now unlocked due to a caching mechanism. The mechanism:

- Creates a SHA256/B64 encoded hash of the current session (minus the expiry date, which changes every time BUT is much larger than our cache length)
- Uses the hash to key the cache entry in mongoDB
- Checks before each request if a cached session object exists for the current session hash
- If so, returns the roles associated with the hash of the session
- If not, hits the discord API

Added unit tests and integration tests. This is now active on all protected routes and requires a Bankless L2 user or a BB-core member.


