### PR TITLE
fix - handle search errors better and createdBy

### DIFF
--- a/mongo/bounties/init.js
+++ b/mongo/bounties/init.js
@@ -1,1 +1,4 @@
+conn = new Mongo();
+db = conn.getDB("bountyboard");
 db.bounties.createIndex({ title: 'text' });
+printjson( db.bounties.createIndex({ title: 'text' }) );

--- a/packages/react-app/src/components/pages/Bounties/Filters/index.tsx
+++ b/packages/react-app/src/components/pages/Bounties/Filters/index.tsx
@@ -16,12 +16,12 @@ import { AcceptedSortInputs } from '@app/types/Filter';
 
 type SetState<T extends any> = (arg: T) => void;
 
-const sortOptions: { name: AcceptedSortInputs, value: string }[] = [
+const sortOptions: { name: string, value: AcceptedSortInputs }[] = [
 	{
-		name: 'createdAt', value: 'Created Date',
+		name: 'Created Date', value: 'createdAt',
 	},
 	{
-		name: 'reward', value: 'Reward',
+		name: 'Reward', value: 'reward',
 	},
 ];
 
@@ -113,7 +113,7 @@ const SortBy = ({ name, options, sortBy, sortAscending, setSortBy, setSortAscend
 			<Select mb="4" onChange={updateSort} value={sortBy}>
 				{options.map((option: { name: string; value: string }) => (
 					<option key={option.name} value={option.value}>
-						{option.value}
+						{option.name}
 					</option>
 				))}
 			</Select>

--- a/packages/react-app/src/components/pages/Bounties/index.tsx
+++ b/packages/react-app/src/components/pages/Bounties/index.tsx
@@ -18,7 +18,7 @@ const maxPages = (bounties: BountyCollection | BountyCollection[] | undefined) =
 	return hasExtraPage ? numFullPages + 1 : numFullPages;
 };
 
-const NoResults = () => (
+const FilterResultPlaceholder = ({ message }: { message: string }): JSX.Element => (
 	<Stack
 		borderWidth={3}
 		borderRadius={10}
@@ -28,7 +28,7 @@ const NoResults = () => (
 		justify="center"
 		align="center"
 	>
-		<Text	fontSize="lg">Found <strong>0</strong> matching results</Text>
+		<Text	fontSize="lg">{ message }</Text>
 	</Stack>
 );
 
@@ -66,8 +66,7 @@ const Bounties = (): JSX.Element => {
 		? bounties.slice(PAGE_SIZE * page, Math.min(bounties.length, PAGE_SIZE * (page + 1)))
 		: [];
 
-	if (isError) return <p>Failed to load</p>;
-	if (isLoading) return <p>Loading</p>;
+	const noResults = ((search || status) && bounties && paginatedBounties.length === 0);
 	return (
 		<>
 			<Stack
@@ -85,9 +84,11 @@ const Bounties = (): JSX.Element => {
 					sortBy={sortBy} setSortBy={setSortBy}
 					sortAscending={sortAscending} setSortAscending={setSortAscending}
 				/>
-				{(search || status) && bounties && paginatedBounties.length === 0
-					? <NoResults />
-					: <BountyAccordion bounties={paginatedBounties} />
+				{isError || noResults
+					? <FilterResultPlaceholder message={'No Results'} />
+					: isLoading
+						? <FilterResultPlaceholder message={'Loading'} />
+						: <BountyAccordion bounties={paginatedBounties} />
 				}
 			</Stack>
 			<BountyPaginate


### PR DESCRIPTION
Search errors due to missing index will not crash the application
Loading will also leave the filters pane rendered
Finally, createdBy was not working as expected because `name` and `value` were the wrong way wrong. Amended