### PR TITLE
add extra roles and remove strict checks preventing role caching

### DIFF
--- a/packages/react-app/src/constants/Roles.ts
+++ b/packages/react-app/src/constants/Roles.ts
@@ -3,6 +3,8 @@ export const BANKLESS_ROLES = {
    * Hardcoded mapping of discord role IDs to some readable names
    * These are in the bankless dao
    */
+	LEVEL_4: '840627393777762344',
+	LEVEL_3: '839005209611075614',
 	LEVEL_2: '839005084016312360',
 	LEVEL_1: '834560235704025108',
 	BB_CORE: '911038195397967892',

--- a/packages/react-app/src/models/RoleCache.ts
+++ b/packages/react-app/src/models/RoleCache.ts
@@ -15,7 +15,12 @@ export const RoleSchema = new Mongoose.Schema({
 	tte: Number,
 	customerId: String,
 	roles: Array,
-});
+},
+{
+	// Mongoose may not accept new fields for previously defined db  
+	strict: false,
+}
+);
 
 export default Mongoose.models.RoleCache as Model<IRoleCache>
 || Mongoose.model<IRoleCache>('RoleCache', RoleSchema);

--- a/packages/react-app/src/services/auth.service.ts
+++ b/packages/react-app/src/services/auth.service.ts
@@ -24,7 +24,13 @@ export const getPermissions = async (accessToken: string, customerId: string): P
 	// note: only currently supports bankless
 	const banklessRolesForUser = await getRolesForUserInGuild(accessToken, customerId);
 	const permissions: Role[] = [];
-	if (banklessRolesForUser.includes(BANKLESS_ROLES.LEVEL_2)) permissions.push('create-bounty');
+	if (
+		banklessRolesForUser.includes(BANKLESS_ROLES.LEVEL_4) ||
+		banklessRolesForUser.includes(BANKLESS_ROLES.LEVEL_3) ||
+		banklessRolesForUser.includes(BANKLESS_ROLES.LEVEL_2) ||
+		banklessRolesForUser.includes(BANKLESS_ROLES.LEVEL_1)
+	) permissions.push('create-bounty', 'claim-bounties');
+
 	if (banklessRolesForUser.includes(BANKLESS_ROLES.BB_CORE)) permissions.push('admin');
 	return permissions;
 };

--- a/packages/react-app/src/types/Role.ts
+++ b/packages/react-app/src/types/Role.ts
@@ -5,6 +5,7 @@ export type Role =
   | 'edit-own-bounty'
   | 'delete-own-bounty'
   | 'edit-bounties'
+  | 'claim-bounties'
   | 'delete-bounties'
   | 'create-customer'
   | 'edit-customer'

--- a/packages/react-app/tests/unit/components/global/header/Menu.spec.tsx
+++ b/packages/react-app/tests/unit/components/global/header/Menu.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import axios from 'axios';
-import { MenuLinks } from '@app/components/global/Header/Menu';
+import { MenuLinks } from '@app/components/global/Header/MenuLinks';
 import { useSession } from 'next-auth/react';
 import { BANKLESS } from '../../../../../src/constants/Bankless';
 import { guilds as guildsStub } from '@tests/stubs/guilds.stub';
@@ -25,7 +25,7 @@ describe('Testing the menu', () => {
 	it('Renders with a warning about the missing guilds', () => {
 		jest.spyOn(axios, 'get').mockImplementation(() => { throw new Error(); });
 		useSessionTest.mockImplementation(() => ({ status: '', data: [] }));
-		render(<MenuLinks isOpen={false}/>);
+		render(<MenuLinks />);
 		expect(spyWarn).toHaveBeenCalled();
 	});
 
@@ -37,7 +37,7 @@ describe('Testing the menu', () => {
 			.mockReturnValueOnce([[BANKLESS], () => console.log('setCustomers')])
 			.mockReturnValueOnce([guildsStub, () => console.log('setGuilds')]);
     
-		render(<MenuLinks isOpen={false}/>);
+		render(<MenuLinks />);
 		const input = screen.getByRole('combobox', { name: 'dao-selector' });
 		expect(input).toBeVisible();
 
@@ -49,7 +49,7 @@ describe('Testing the menu', () => {
 			.mockReturnValueOnce([[BANKLESS], () => console.log('setCustomers')])
 			.mockReturnValueOnce([guildsStub, () => console.log('setGuilds')]);
 
-		render(<MenuLinks isOpen={false}/>);
+		render(<MenuLinks />);
 		const input = screen.queryByRole('combobox', { name: 'dao-selector' });
 		expect(input).toBeNull();
 	});


### PR DESCRIPTION
Role caching can fail due to mongoose not writing fields if documents exist already.

Also, we need L1, L3, L4s to have access.