### PR TITLE
Fix/discord logout

### DIFF
--- a/packages/react-app/src/components/global/Header/DAOSelector.tsx
+++ b/packages/react-app/src/components/global/Header/DAOSelector.tsx
@@ -39,8 +39,8 @@ export const DAOSelector = ({
 			h={{ base: '3em', md: '2.6em' }}
 			textAlign={{ base: 'center', md:'start' }}
 		>
-      customers &&{' '}
-			{customers.map((option) => (
+      
+			{customers && customers.map((option) => (
 				<option key={option.customerId} value={option.customerName}>
 					{option.customerName}
 				</option>

--- a/packages/react-app/src/components/global/Header/MenuLinks.tsx
+++ b/packages/react-app/src/components/global/Header/MenuLinks.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import AccessibleLink from '../../parts/AccessibleLink';
 import { Button, Text } from '@chakra-ui/react';
-import { useSession } from 'next-auth/react';
+import { signOut, useSession } from 'next-auth/react';
 import { CustomerProps } from '../../../models/Customer';
 import { BANKLESS } from '../../../constants/Bankless';
 import { DiscordGuild } from '../../../types/Discord';
@@ -52,9 +52,8 @@ export const MenuLinks = () => {
 	);
 
 	if (error) {
-		console.warn(
-			'Unable to fetch guilds for the current user, ensure the permissions are correctly set'
-		);
+		signOut();
+		console.warn('Problem fetching guilds in discord api - please sign in again');
 	}
 
 	useEffect(() => {
@@ -77,20 +76,20 @@ export const MenuLinks = () => {
 	}, [session, guilds]);
 	return (
 		<>
-			{<DAOSelector customers={customers} />}
+			<DAOSelector customers={customers} />
 			<MenuItem newTab={false}>
-				{status === 'loading' ? (
-					<span>Loading...</span>
-				) : (
-					<Button
-						onClick={() => toggleDiscordSignIn(session)}
-						id="DiscordButton"
-						w={{ base: '20em', md: 'auto' }}
-						h={{ base: '3em', md: '2.6em' }}
-					>
-						{session ? session.user?.name : 'Join DAO'}
-					</Button>
-				)}
+				{status === 'loading'
+					? (<span>Loading...</span>)
+					: (
+						<Button
+							onClick={() => toggleDiscordSignIn(session)}
+							id="DiscordButton"
+							w={{ base: '20em', md: 'auto' }}
+							h={{ base: '3em', md: '2.6em' }}
+						>
+							{session ? session.user?.name : 'Join DAO'}
+						</Button>
+					)}
 			</MenuItem>
 			<NewBounty />
 		</>

--- a/packages/react-app/src/components/global/Header/MenuLinks.tsx
+++ b/packages/react-app/src/components/global/Header/MenuLinks.tsx
@@ -29,6 +29,7 @@ const MenuItem = ({
 	</AccessibleLink>
 );
 
+
 export const tokenFetcher = (url: string, token: string): any =>
 	axios
 		.get(url, {
@@ -37,24 +38,28 @@ export const tokenFetcher = (url: string, token: string): any =>
 			},
 		})
 		.then((res) => res.data)
-		.catch((error) => console.warn(error));
+		.catch(handleError);
 
-export const MenuLinks = () => {
+const handleError = (error: any): void => {
+	if (error && error.response && error.response.status === 401) {
+		console.warn('401 Problem fetching guilds in discord api - signing out');
+		signOut();
+	} else {
+		throw error;
+	}
+};
+
+export const MenuLinks = (): JSX.Element => {
 	const { data: session, status } = useSession({ required: false });
 	const [customers, setCustomers] = useState<CustomerProps[]>([BANKLESS]);
 	const [guilds, setGuilds] = useState<DiscordGuild[]>();
 
-	const { data: guildApiResponse, error } = useSWR<DiscordGuild[], unknown>(
+	const { data: guildApiResponse } = useSWR<DiscordGuild[], unknown>(
 		session
 			? ['https://discord.com/api/users/@me/guilds', session.accessToken]
 			: null,
 		tokenFetcher
 	);
-
-	if (error) {
-		signOut();
-		console.warn('Problem fetching guilds in discord api - please sign in again');
-	}
 
 	useEffect(() => {
 		const guildsExist = guildApiResponse && guildApiResponse.length > 0;

--- a/packages/react-app/tests/unit/components/global/header/Menu.spec.tsx
+++ b/packages/react-app/tests/unit/components/global/header/Menu.spec.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import { MenuLinks } from '@app/components/global/Header/MenuLinks';
 import { useSession } from 'next-auth/react';
-import { BANKLESS } from '../../../../../src/constants/Bankless';
-import { guilds as guildsStub } from '@tests/stubs/guilds.stub';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
 jest.mock('next-auth/react', () => ({
 	useSession: jest.fn(),
@@ -12,35 +10,48 @@ jest.mock('next-auth/react', () => ({
 }));
 
 describe('Testing the menu', () => {
-	jest.spyOn(console, 'error')
-		.mockImplementation(() => console.log('Supressed Console Error'));
-
+	let spyWarn: jest.SpyInstance;
 	beforeEach(() => {
-		jest.clearAllMocks();
+		jest.spyOn(axios, 'post').mockResolvedValue({ data: { data: [] } });
+		spyWarn = jest.spyOn(console, 'warn');
 	});
+
+	afterEach(() => jest.resetAllMocks());
 
 	const useSessionTest = useSession as typeof useSession & any;
-	// supress and monitor console warnings
-	const spyWarn = jest.spyOn(console, 'warn').mockImplementation(() => false);
+	
+	it('Shows the selector if signed in and if there are customers', async () => {
+		useSessionTest.mockImplementation(() => ({ status: 'Done', data: {} }));
+		
+		// async state updates require wrapping component in act then using waitFor to listen for promise resolution
+		act(() => {
+			render(<MenuLinks />);
+		});
+		
+		const input = screen.getByRole('combobox', { name: 'dao-selector' });
+		await waitFor(() => expect(input).toBeVisible());
 
-	it('Renders with a warning about the missing guilds', () => {
-		jest.spyOn(axios, 'get').mockImplementation(() => { throw new Error(); });
-		useSessionTest.mockImplementation(() => ({ status: '', data: [] }));
-		render(<MenuLinks />);
-		expect(spyWarn).toHaveBeenCalled();
 	});
 
-	it('Shows the selector if signed in and if there are customers', () => {
-		jest.spyOn(axios, 'get').mockReturnValue(Promise.resolve({ data: guildsStub }));
-    
+	it('Token fetcher signs the user out on 401', async () => {
+		jest.spyOn(axios, 'get').mockRejectedValue({ response: { status: 401 } });
 		useSessionTest.mockImplementation(() => ({ status: 'Done', data: {} }));
-		jest.spyOn(React, 'useState')
-			.mockReturnValueOnce([[BANKLESS], () => console.log('setCustomers')])
-			.mockReturnValueOnce([guildsStub, () => console.log('setGuilds')]);
-    
-		render(<MenuLinks />);
-		const input = screen.getByRole('combobox', { name: 'dao-selector' });
-		expect(input).toBeVisible();
+		
+		act(() => {
+			render(<MenuLinks />);
+		});
+		
+		await waitFor(() => expect(spyWarn).toHaveBeenNthCalledWith(1, '401 Problem fetching guilds in discord api - signing out'));
+	});
 
+	it('Token fetcher does not sign the user out on 400 or other errors', async () => {
+		jest.spyOn(axios, 'get').mockRejectedValue({ response: { status: 400 } });
+		useSessionTest.mockImplementation(() => ({ status: 'Done', data: {} }));
+		
+		act(() => {
+			render(<MenuLinks />);
+		});
+		
+		await waitFor(() => expect(spyWarn).not.toHaveBeenNthCalledWith(1, '401 Problem fetching guilds in discord api - signing out'));
 	});
 });

--- a/packages/react-app/tests/unit/components/global/header/Menu.spec.tsx
+++ b/packages/react-app/tests/unit/components/global/header/Menu.spec.tsx
@@ -8,6 +8,7 @@ import { render, screen } from '@testing-library/react';
 
 jest.mock('next-auth/react', () => ({
 	useSession: jest.fn(),
+	signOut: jest.fn(),
 }));
 
 describe('Testing the menu', () => {
@@ -41,16 +42,5 @@ describe('Testing the menu', () => {
 		const input = screen.getByRole('combobox', { name: 'dao-selector' });
 		expect(input).toBeVisible();
 
-	});
-
-	it('Does not show the selector if we are not signed in', () => {
-		useSessionTest.mockImplementation(() => ({ status: undefined, data: undefined }));
-		jest.spyOn(React, 'useState')
-			.mockReturnValueOnce([[BANKLESS], () => console.log('setCustomers')])
-			.mockReturnValueOnce([guildsStub, () => console.log('setGuilds')]);
-
-		render(<MenuLinks />);
-		const input = screen.queryByRole('combobox', { name: 'dao-selector' });
-		expect(input).toBeNull();
 	});
 });


### PR DESCRIPTION
For reasons I can't quite work out, discord access tokens seem to invalidate after a period less than their expiry. This causes all sorts of confusing issues for users.

While we look to understand the problem more, this forces a sign out if one of our methods returns a 401, which at the very least forces the user to login again, thereby hiding the problem from the user's perspective