### PR TITLE
feature/paidStatus: added paidStatus to bounty model and to BountySummary component

### DIFF
--- a/packages/react-app/src/components/global/Header/DiscordBttn.tsx
+++ b/packages/react-app/src/components/global/Header/DiscordBttn.tsx
@@ -7,7 +7,7 @@ export default function DiscordBttn({
 	session,
 }: {
   session: Session | unknown;
-}) {
+}): JSX.Element {
 	return (
 		<Button
 			onClick={() => toggleDiscordSignIn(session)}

--- a/packages/react-app/src/components/pages/Bounties/Bounty/index.tsx
+++ b/packages/react-app/src/components/pages/Bounties/Bounty/index.tsx
@@ -16,6 +16,7 @@ import { BountyCollection } from '@app/models/Bounty';
 import BountyClaim from './claim';
 import BountySubmit from './submit';
 import { BountyEditButton } from './edit';
+import PAID_STATUS from '@app/constants/paidStatus';
 
 const Status = ({ indication }: { indication: string }): JSX.Element => (
 	<Tag my={0} size="lg" key="lg" variant="outline" colorScheme={indication}>
@@ -63,8 +64,13 @@ const BountySummary = ({ bounty }: { bounty: BountyCollection }): JSX.Element =>
 				)}
 			</Box>
 			<Flex width="full" justifyContent="space-between" alignItems="center">
-				<Box mb={2} >
+				<Box mb={2}>
 					{bounty.status && <Status indication={bounty.status} />}
+				</Box>
+			</Flex>
+			<Flex width="full" justifyContent="space-between" alignItems="center">
+				<Box mb={2}>
+					{<Status indication={bounty.paidStatus ? bounty.paidStatus : PAID_STATUS.UNPAID} />}
 				</Box>
 			</Flex>
 		</Flex>

--- a/packages/react-app/src/components/pages/Bounties/Form/FormFields.tsx
+++ b/packages/react-app/src/components/pages/Bounties/Form/FormFields.tsx
@@ -47,7 +47,7 @@ const HelperBox = (props: { children?: React.ReactNode, text?: string } & BoxPro
 	</Box>
 );
 
-function BountyFormFields(props: { formProps: UseFormReturn<typeof bountyFormFieldValues> }) {
+function BountyFormFields(props: { formProps: UseFormReturn<typeof bountyFormFieldValues> }): JSX.Element {
 	const currencies = useCurrencies();
 	const {
 		register,

--- a/packages/react-app/src/components/pages/Bounties/Form/NewBountyForm.tsx
+++ b/packages/react-app/src/components/pages/Bounties/Form/NewBountyForm.tsx
@@ -30,6 +30,7 @@ const NotNeededFields = [
 	'reviewedAt',
 	'reviewedBy',
 	'submittedBy',
+	'paidStatus',
 ] as const;
 
 const useCachedForm = () => {

--- a/packages/react-app/src/components/parts/ColorModeButton.tsx
+++ b/packages/react-app/src/components/parts/ColorModeButton.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonProps, useColorMode } from '@chakra-ui/react';
 
 const ColorModeButton = (props: ButtonProps & {
   children?: React.ReactNode
-}) => {
+}): JSX.Element => {
 	const { colorMode } = useColorMode();
 	return (
 		<Button

--- a/packages/react-app/src/constants/paidStatus.ts
+++ b/packages/react-app/src/constants/paidStatus.ts
@@ -1,0 +1,10 @@
+import { ObjectValues } from '@app/types';
+
+export const PAID_STATUS = {
+	UNPAID: 'Unpaid',
+	PAID: 'PAID',
+} as const;
+
+export type PAID_STATUS_VALUES = ObjectValues<typeof PAID_STATUS>;
+
+export default PAID_STATUS;

--- a/packages/react-app/src/models/Bounty.ts
+++ b/packages/react-app/src/models/Bounty.ts
@@ -14,6 +14,7 @@ import {
 // @ts-ignore
 import mongoosePaginate from 'mongo-cursor-pagination';
 import BOUNTYSTATUS from '@app/constants/bountyStatus';
+import PAIDSTATUS from '@app/constants/paidStatus';
 import ACTIVITY, { CLIENT } from '@app/constants/activity';
 
 type RequiredForPostProps = { method: 'POST' | 'PATCH', schema: any, isObject?: boolean };
@@ -87,6 +88,7 @@ export const Reward = object({
 );
 
 export const status = mixed().oneOf(Object.values(BOUNTYSTATUS));
+export const paidStatus = mixed().oneOf(Object.values(PAIDSTATUS));
 export const activity = mixed().oneOf(Object.values(ACTIVITY));
 export const client = mixed().oneOf(Object.values(CLIENT));
 
@@ -108,6 +110,7 @@ export const BountySchema = object({
 	criteria: string().when('$method', (method, schema) => requiredForPost({ method, schema })),
 	customerId: string().when('$method', (method, schema) => requiredForPost({ method, schema })),
 	status: status.when('$method', (method, schema) => requiredForPost({ method, schema })),
+	paidStatus: paidStatus.when('$method', (method, schema) => requiredForPost({ method, schema })),
 	dueAt: string().when('$method', (method, schema) => requiredForPost({ method, schema })),
 	reward: Reward.when('$method', (method, schema) => requiredForPost({ method, schema, isObject: true })),
 	
@@ -200,6 +203,11 @@ export const BountyBoardSchema = new mongoose.Schema({
 	},
 	statusHistory: {
 		type: Array,
+	},
+	paidStatus: {
+		/* Bounty Paid Status */
+		/* "Unpaid", "Paid" */
+		type: String,
 	},
 	activityHistory: {
 		type: Array,

--- a/packages/react-app/src/styles/customTheme.ts
+++ b/packages/react-app/src/styles/customTheme.ts
@@ -43,6 +43,8 @@ export const baseTheme = extendTheme({
 		Deleted: theme.colors.red,
 		Draft: theme.colors.gray,
 		primary: theme.colors.teal,
+		Paid: theme.colors.green,
+		Unpaid: theme.colors.gray,
 	},
 	components: {
 		Heading: {


### PR DESCRIPTION
Quick unit of work to add `paidStatus` to bounties to unblock tescher@'s work on CSV exports

Added paid status to `BountySummary`. To stay backwards compatible, if `paidStatus` is not specified for a bounty, we default to 'Unpaid'. 

Styling wise, I chose to stack paid status underneath bounty status. There are definitely better ways to style it, but all of this will be overwritten soon anyways with links@ UI updates to bounty cards.