### PR TITLE
FIX bug #260 missing yarn dependency esprima

### DIFF
--- a/packages/react-app/.env.qa
+++ b/packages/react-app/.env.qa
@@ -1,6 +1,6 @@
 BUILD_ENV=development
 MONGODB_DB=bountyboard
-MONGODB_URI=
+MONGODB_URI=mongodb://mongo:27017/bountyboard
 
 # Support Channels and Feedback
 BOUNTY_BOARD_DISCORD_SUPPORT_CHANNEL=834499078434979893

--- a/yarn.lock
+++ b/yarn.lock
@@ -4920,10 +4920,6 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esprima@substack/esprima#is-keyword:
-  version "1.1.0-dev"
-  resolved "https://codeload.github.com/substack/esprima/tar.gz/0a7f8489a11b44b019ce168506f535f22d0be290"
-
 esquery@^1.0.1, esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
@@ -5395,7 +5391,6 @@ falafel@~0.2.1:
   resolved "https://registry.yarnpkg.com/falafel/-/falafel-0.2.1.tgz#9efc51ce19ec5729086b22ae889e5d7d0e256601"
   integrity sha1-nvxRzhnsVykIayKuiJ5dfQ4lZgE=
   dependencies:
-    esprima substack/esprima#is-keyword
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
Removed reference entirely esprima@substack/esprima#is-keyword out of yarn.lock as it's no longer needed. yarn dev then loads properly. 